### PR TITLE
* fix to make trust store work on ibm jvm

### DIFF
--- a/src/main/java/javapns/communication/ConnectionToAppleServer.java
+++ b/src/main/java/javapns/communication/ConnectionToAppleServer.java
@@ -26,7 +26,7 @@ public abstract class ConnectionToAppleServer {
 	protected static final Logger logger = Logger.getLogger(ConnectionToAppleServer.class);
 
 	/* The algorithm used by KeyManagerFactory */
-	private static final String ALGORITHM = "sunx509";
+	private static final String ALGORITHM = KeyManagerFactory.getDefaultAlgorithm();
 
 	/* The protocol used to create the SSLSocket */
 	private static final String PROTOCOL = "TLS";


### PR DESCRIPTION
the "sunx509" algorithm is not available on IBM virtual machines, using the default algorithm works just fine though.
