### PR TITLE
Queue implementation change

### DIFF
--- a/src/main/java/javapns/notification/PushNotificationManager.java
+++ b/src/main/java/javapns/notification/PushNotificationManager.java
@@ -536,12 +536,12 @@ public class PushNotificationManager {
 							// has to be resend (after the error package)
 							if (invalidTokens.contains(noti.getDevice().getToken())) {
 								// skip if device token is already blacklisted
-								pushedNotifications.remove(noti.getIdentifier());
+								it.remove();
 								continue;
 							}
 							//sanity check, incase we get a response on a later entry when we already have a response on an earlier one.
 							if (noti.getResponse() != null && noti.getResponse().getStatus() == 8) {
-								pushedNotifications.remove(noti.getIdentifier());
+								it.remove();
 								continue;
 							}
 							try {

--- a/src/main/java/javapns/notification/ResponsePacketReader.java
+++ b/src/main/java/javapns/notification/ResponsePacketReader.java
@@ -77,7 +77,7 @@ class ResponsePacketReader {
 	}
 
 
-	private static ResponsePacket readResponsePacketData(InputStream input) throws IOException {
+	public static ResponsePacket readResponsePacketData(InputStream input) throws IOException {
 		int command = input.read();
 		if (command < 0) return null;
 		int status = input.read();


### PR DESCRIPTION
Changed the way the queue implementation sends and handles pushes

The old implementation had a hard time dealing with invalid tokens. If an invalid token was sent through the socket then apple sends a response and closes the socket. Due to this being async a lot of other notifications were sent through the socket that might have been fine or invalid but were discarded all together.

Added a listening thread to keep listening for responses from apple. Adds the response to the errorlist and then restarts the connection on the next push and handles the errors.
Also holds a list of tokens that are confirmed invalid for feedback purposes but also to not try sending to those tokens again (so the socket doesn't have to go bust and handle the errors again for that specific token)

Set a minimum sleep timer on the queue to not flood the queue, should be fine when no errors but quite time consuming when there are and you send 500 extra pushes over the socket that have to be handled by the error handling again and again. 

Half clears the pushed notifications list to keep memory in check on that map (keep the newer ones there for the async feedback / error handling)
